### PR TITLE
add text-decoration-none on icon link

### DIFF
--- a/orif/common/Views/items_list.php
+++ b/orif/common/Views/items_list.php
@@ -156,21 +156,24 @@
                     <td class="text-right">                        
                         <!-- Bootstrap details icon ("Card text"), redirect to url_detail, adding /primary_key as parameter -->
                         <?php if(isset($url_detail)) { ?>
-                            <a href="<?= site_url(esc($url_detail.$itemEntity[$primary_key_field])) ?>">
+                            <a href="<?= site_url(esc($url_detail.$itemEntity[$primary_key_field])) ?>"
+                                    class="text-decoration-none" >
                                 <i class="bi-card-text" style="font-size: 20px;"></i>
                             </a>
                         <?php } ?>
 
                         <!-- Bootstrap edit icon ("Pencil"), redirect to url_update, adding /primary_key as parameter -->
                         <?php if(isset($url_update)) { ?>
-                            <a href="<?= site_url(esc($url_update.$itemEntity[$primary_key_field])) ?>">
+                            <a href="<?= site_url(esc($url_update.$itemEntity[$primary_key_field])) ?>"
+                                    class="text-decoration-none" >
                                 <i class="bi-pencil" style="font-size: 20px;"></i>
                             </a>
                         <?php } ?>
                         
                         <!-- Bootstrap delete icon ("Trash"), redirect to url_delete, adding /primary_key as parameter -->
                         <?php if(isset($url_delete)) { ?>
-                            <a href="<?= site_url(esc($url_delete.$itemEntity[$primary_key_field])) ?>">
+                            <a href="<?= site_url(esc($url_delete.$itemEntity[$primary_key_field])) ?>"
+                                    class="text-decoration-none" >
                                 <i class="bi-trash" style="font-size: 20px;"></i>
                             </a>
                         <?php } ?>


### PR DESCRIPTION
![image](https://github.com/OrifInformatique/ci_packbase_v4/assets/24254885/6b6c26c6-4bbc-4cc0-b006-97e35b2307eb)
Remove the underline space when the mouse is over the icon.