### PR TITLE
print item entities in the same order of the columns

### DIFF
--- a/orif/common/Views/items_list.php
+++ b/orif/common/Views/items_list.php
@@ -9,6 +9,7 @@
      * @param list_title : String displayed on the top of the list.
      * @param items :      Array of items to display, each item being a subarray with multiple properties.
      * @param columns :    Array of columns to display in the list.
+     *                     Columns display order is the same as the order given in this parameter.
      *                     Key is the name of the corresponding items property in items subarrays.
      *                     Value is the header to display for each column.
      * @param with_deleted : 

--- a/orif/common/Views/items_list.php
+++ b/orif/common/Views/items_list.php
@@ -147,7 +147,11 @@
                 <tr>
                     <!-- Only display item's properties wich are listed in "columns" variable in the order of the columns -->
                     <?php foreach ($columns as $columnKey => $column): ?>
-                        <td><?= $itemEntity[$columnKey] ?></td>
+                        <?php if (array_key_exists($columnKey, $itemEntity)) : ?>
+                            <td><?= $itemEntity[$columnKey] ?></td>
+                        <?php else: ?>
+                            <td></td>
+                        <?php endif ?>
                     <?php endforeach ?>
                     
                     <!-- Add the "action" column (for detail/update/delete links) -->

--- a/orif/common/Views/items_list.php
+++ b/orif/common/Views/items_list.php
@@ -145,12 +145,10 @@
                 <!-- One table row for each item -->
                 <?php foreach ($items as $itemEntity): ?>
                 <tr>
-                    <!-- Only display item's properties wich are listed in "columns" variable -->
-                    <?php foreach ($itemEntity as $propertyKey => $propertyValue): 
-                        if (array_key_exists($propertyKey, $columns)) {
-                            echo ('<td>'.$propertyValue.'</td>');
-                        }
-                    endforeach ?>
+                    <!-- Only display item's properties wich are listed in "columns" variable in the order of the columns -->
+                    <?php foreach ($columns as $columnKey => $column): ?>
+                        <td><?= $itemEntity[$columnKey] ?></td>
+                    <?php endforeach ?>
                     
                     <!-- Add the "action" column (for detail/update/delete links) -->
                     <td class="text-right">                        


### PR DESCRIPTION
![image](https://github.com/OrifInformatique/ci_packbase_v4/assets/24254885/9495402d-0607-4e38-9a35-0bd0e1fa3874)
Before this commit, the list view just checked if the column array contained the same key as the item array. With this commit, the item array is printed in the same order as the column array.