### PR TITLE
add a default view with layout that can be extends by view in module

### DIFF
--- a/orif/common/Views/default.php
+++ b/orif/common/Views/default.php
@@ -1,0 +1,31 @@
+<?php
+/**
+ * Default view
+ *
+ * @author      Orif
+ * @link        https://github.com/OrifInformatique
+ * @copyright   Copyright (c), Orif (https://www.orif.ch)
+ */
+?>
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+    <?= view('Common\Views\head_content', $this->data) ?>
+    <?= $this->renderSection('head') ?>
+</head>
+<body>
+    <?php if (ENVIRONMENT != 'production'): ?>
+        <div class="alert alert-warning text-center">CodeIgniter environment variable is set to
+        <?=esc(strtoupper(ENVIRONMENT))?> You can change it in .env file.</div>
+    <?php endif ?>
+    <?= view('Common\Views\login_bar', $this->data) ?>
+    <?php foreach (config('Common\Config\AdminPanelConfig')->tabs as $tab) {
+            if (strstr(current_url(),$tab['pageLink'])) {
+                $textView .= view('\Common\adminMenu');
+            }
+        }
+    ?>
+    <?= $this->renderSection('content') ?>
+<?= $this->renderSection('javascript') ?>
+</body>
+</html>

--- a/orif/common/Views/default.php
+++ b/orif/common/Views/default.php
@@ -21,7 +21,7 @@
     <?= view('Common\Views\login_bar', $this->data) ?>
     <?php foreach (config('Common\Config\AdminPanelConfig')->tabs as $tab) {
             if (strstr(current_url(),$tab['pageLink'])) {
-                $textView .= view('\Common\adminMenu');
+                echo view('\Common\adminMenu');
             }
         }
     ?>

--- a/orif/common/Views/head_content.php
+++ b/orif/common/Views/head_content.php
@@ -1,0 +1,35 @@
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+<!-- Copied from Bootstrap model https://getbootstrap.com/docs/4.6/getting-started/introduction/) -->
+
+<title><?php
+    if (!isset($title) || is_null($title) || $title == '') {
+        echo lang('common_lang.page_prefix');
+    } else {
+        echo lang('common_lang.page_prefix').' - '.$title;
+    }
+?></title>
+<!-- Icon -->
+<link rel="icon" type="image/png" href="<?= base_url("images/favicon.png"); ?>">
+<link rel="shortcut icon" type="image/png" href="<?= base_url("images/favicon.png"); ?>">
+
+<!-- Bootstrap  -->
+<!-- Orif Bootstrap CSS personalized with https://bootstrap.build/app -->
+<link rel="stylesheet" href="<?= base_url("css/bootstrap.min.css"); ?>">
+<!-- Bootstrap icons -->
+<link rel="stylesheet" href="<?= base_url("css/bootstrap-icons-1.10.5/font/bootstrap-icons.min.css"); ?>">
+<!-- jquery, popper and Bootstrap javascript -->
+<script src="https://code.jquery.com/jquery-3.5.1.min.js" crossorigin="anonymous"></script>
+<script src="https://cdn.jsdelivr.net/npm/popper.js@1.16.1/dist/umd/popper.min.js" integrity="sha384-9/reFTGAW83EW2RDu2S0VKaIzap3H66lZH81PoYlFhbGU+6BZp6G7niu735Sk7lN" crossorigin="anonymous"></script>
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@4.6.0/dist/js/bootstrap.min.js" integrity="sha384-+YQ4JLhjyBLPDQt//I+STsc9iw4uQqACwlvpslubQzn4u2UU2UFM80nGisd026JF" crossorigin="anonymous"></script>
+
+
+<!-- HTML5 shim and Respond.js for IE8 support of HTML5 elements and media queries -->
+<!-- WARNING: Respond.js doesn't work if you view the page via file:// -->
+<!--[if lt IE 9]>
+  <script src="https://oss.maxcdn.com/html5shiv/3.7.2/html5shiv.min.js"></script>
+  <script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
+<![endif]-->
+
+<!-- Application styles -->
+<link rel="stylesheet" href="<?= base_url("css/MY_styles.css"); ?>">

--- a/orif/common/Views/header.php
+++ b/orif/common/Views/header.php
@@ -10,46 +10,10 @@
 <!DOCTYPE html>
 <html lang="fr">
 <head>
-    <meta charset="utf-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-    <!-- Copied from Bootstrap model https://getbootstrap.com/docs/4.6/getting-started/introduction/) -->
-
-    <title><?php
-        if (!isset($title) || is_null($title) || $title == '') {
-            echo lang('common_lang.page_prefix');
-        } else {
-            echo lang('common_lang.page_prefix').' - '.$title;
-        }
-    ?></title>
-
-    <!-- Icon -->
-    <link rel="icon" type="image/png" href="<?= base_url("images/favicon.png"); ?>" />
-    <link rel="shortcut icon" type="image/png" href="<?= base_url("images/favicon.png"); ?>" />
-
-    <!-- Bootstrap  -->
-    <!-- Orif Bootstrap CSS personalized with https://bootstrap.build/app -->
-    <link rel="stylesheet" href="<?= base_url("css/bootstrap.min.css"); ?>" />
-    <!-- Bootstrap icons -->
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.5.0/font/bootstrap-icons.css">
-    <!-- jquery, popper and Bootstrap javascript -->
-    <script src="https://code.jquery.com/jquery-3.5.1.min.js" crossorigin="anonymous"></script>
-    <script src="https://cdn.jsdelivr.net/npm/popper.js@1.16.1/dist/umd/popper.min.js" integrity="sha384-9/reFTGAW83EW2RDu2S0VKaIzap3H66lZH81PoYlFhbGU+6BZp6G7niu735Sk7lN" crossorigin="anonymous"></script>
-    <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.6.0/dist/js/bootstrap.min.js" integrity="sha384-+YQ4JLhjyBLPDQt//I+STsc9iw4uQqACwlvpslubQzn4u2UU2UFM80nGisd026JF" crossorigin="anonymous"></script>
-
-
-    <!-- HTML5 shim and Respond.js for IE8 support of HTML5 elements and media queries -->
-    <!-- WARNING: Respond.js doesn't work if you view the page via file:// -->
-    <!--[if lt IE 9]>
-      <script src="https://oss.maxcdn.com/html5shiv/3.7.2/html5shiv.min.js"></script>
-      <script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
-    <![endif]-->
-
-    <!-- Application styles -->
-    <link rel="stylesheet" href="<?= base_url("css/MY_styles.css"); ?>" />
+    <?= view('Common\Views\head_content', $this->data) ?>
 </head>
 <body>
-    <?php
-        if (ENVIRONMENT != 'production') {
-            echo '<div class="alert alert-warning text-center">CodeIgniter environment variable is set to '.strtoupper(ENVIRONMENT).'. You can change it in .env file.</div>';
-        }
-    ?>
+    <?php if (ENVIRONMENT != 'production'): ?>
+        <div class="alert alert-warning text-center">CodeIgniter environment variable is set
+        to <?=esc(strtoupper(ENVIRONMENT))?> You can change it in .env file.</div>
+    <?php endif ?>


### PR DESCRIPTION
# Add View Layout
Instead of editing display_view that cause incompatibility with other site (https://github.com/OrifInformatique/ci_packbase_v4/pull/57), add a default view that use layout (https://www.codeigniter.com/user_guide/outgoing/view_layouts.html) and must be extended by the views in modules. This change permits to use the view function of CodeIgniter that return a string and permits to have a view with a different header without rewrite all the head.
# Example
## default.php
The default view with renderSection that will be replaced by what you want when you extend this view. The default view is like an abstract class, it is not supposed to be used without extends

```php
<!DOCTYPE html>
<html lang="fr">
<head>
    <?= view('Common\Views\head_content', $this->data) ?>
    <?= $this->renderSection('head') ?>
</head>
<body>
    <?php if (ENVIRONMENT != 'production'): ?>
        <div class="alert alert-warning text-center">CodeIgniter environment variable is set to
        <?=esc(strtoupper(ENVIRONMENT))?> You can change it in .env file.</div>
    <?php endif ?>
    <?= view('Common\Views\login_bar', $this->data) ?>
    <?php foreach (config('Common\Config\AdminPanelConfig')->tabs as $tab) {
            if (strstr(current_url(),$tab['pageLink'])) {
                $textView .= view('\Common\adminMenu');
            }
        }
    ?>
    <?= $this->renderSection('content') ?>
<?= $this->renderSection('javascript') ?>
</body>
</html>
```
### Note
I put the content of the head in head_content.php to have the same thing between the current header.php and this default view without duplicate the code.
## edit_planning.php
The edit planning view extends the default view and defines a section that will be inserted in the default view. There are no error if all sections are not be defined, it is just replaced by nothing.

```php
<?= $this->extend('Common\Views\default') ?>
<?= $this->section('head') ?>
    <?= view('Timbreuse\Views\planning\edit_planning_style') ?>
<?= $this->endSection() ?>
<?= $this->section('content') ?>
<section class="container">
    <h3><?= esc($h3title) ?></h3>
    <?php if (! empty(service('validation')->getErrors())) : ?>
        <div class="alert alert-danger" role="alert">
            <?= service('validation')->listErrors() ?>
        </div>
    <?php endif ?>
    <form class="grid-container" method="post">
        <!-- cut because not important for example -->
    </form>
    <details>
         <!-- cut because not important for example -->
    </details>
</section>
<?= $this->endSection() ?>
<?= $this->section('javascript') ?>
    <?= view('Timbreuse\Views\planning\edit_planning_script') ?>
<?= $this->endSection() ?>
```
### Note
* I put the content of CSS style in edit_planning_style.php. I don’t use link and CSS file because CSS file must be in the public directory and that avoid having an independent module. This file begins with `<style>` and ends with `</style>`.
* I put the content of JavaScript script in edit_planning_script.php. I don’t use link and JS file because JS file must be in the public directory and that avoid having an independent module. This file begins with `<script>` and ends with `</script>`.
## Call
Use the view function of CodeIgniter. 
``` php
        return view('Timbreuse\Views\planning\edit_planning.php', $data);
```
All part will be renderer. 
![image](https://github.com/OrifInformatique/ci_packbase_v4/assets/24254885/f1db7491-f3ac-4ca3-b073-e9a2ab4142a7)
