### PR TITLE
fix: test not fail when exit

### DIFF
--- a/.github/workflows/codeigniter.yml
+++ b/.github/workflows/codeigniter.yml
@@ -61,4 +61,5 @@ jobs:
         CLIENT_SECRET: ${{ secrets.CLIENT_SECRET }}
         GRAPH_USER_SCOPES: ${{ secrets.GRAPH_USER_SCOPES }}
         REDIRECT_URI: ${{ secrets.REDIRECT_URI }}
-      run: vendor/bin/phpunit
+      run: vendor/bin/phpunit --stop-on-error --stop-on-failure\
+        || (vendor/bin/phpunit; false)


### PR DESCRIPTION
The exit, die and dd functions quit the process of testing with a code error of 0 that is considering like success by shells and GitHub Actions.
# Change:
- Tests return a fail when one test fails.

# Remain problem:
- If there is no error between the start of the tests and an exit function, the tests are considered successful, but they are not. 